### PR TITLE
Fixed deprecated noteOn call -> start

### DIFF
--- a/game.coffee
+++ b/game.coffee
@@ -80,7 +80,7 @@ play = (name, time) ->
   source = audioCtx.createBufferSource()
   source.buffer = sounds[name]
   source.connect mixer
-  source.noteOn time ? 0
+  source.start time ? 0
   source
 
 toggleMute = ->


### PR DESCRIPTION
An update to the Audio API and AudioBufferSourceNode, changed the function name.
